### PR TITLE
Add output file template

### DIFF
--- a/cmd/gb/build.go
+++ b/cmd/gb/build.go
@@ -45,7 +45,7 @@ var (
 
 func addBuildFlags(fs *flag.FlagSet) {
 	// TODO(dfc) this should accept a *gb.Context
-	fs.StringVar(&outputFileTemplate, "o", "", "output file template. possible placeholders: target_path, tags: example: `gb build -o '{{.target_path}}-{{.tags}}'`")
+	fs.StringVar(&outputFileTemplate, "o", "", "output file template")
 	fs.BoolVar(&R, "r", false, "perform a release build")
 	fs.BoolVar(&F, "f", false, "rebuild up-to-date packages")
 	fs.BoolVar(&FF, "F", false, "do not cache built packages")
@@ -67,6 +67,10 @@ dependencies.
 
 Flags:
 
+	-o
+		changes output binary file name. golang template expected.
+		possible placeholders: target_path, tags.
+		example: gb build -o '{{.target_path}}-{{.tags}}'
 	-f
 		ignore cached packages if present, new packages built will overwrite
 		any cached packages. This effectively disables incremental

--- a/cmd/gb/build.go
+++ b/cmd/gb/build.go
@@ -39,10 +39,13 @@ var (
 	dotfile string // path to dot output file
 
 	buildtags []string
+
+	outputFileName string
 )
 
 func addBuildFlags(fs *flag.FlagSet) {
 	// TODO(dfc) this should accept a *gb.Context
+	fs.StringVar(&outputFileName, "o", "", "output file name")
 	fs.BoolVar(&R, "r", false, "perform a release build")
 	fs.BoolVar(&F, "f", false, "rebuild up-to-date packages")
 	fs.BoolVar(&FF, "F", false, "do not cache built packages")

--- a/cmd/gb/build.go
+++ b/cmd/gb/build.go
@@ -40,12 +40,12 @@ var (
 
 	buildtags []string
 
-	outputFileName string
+	outputFileTemplate string
 )
 
 func addBuildFlags(fs *flag.FlagSet) {
 	// TODO(dfc) this should accept a *gb.Context
-	fs.StringVar(&outputFileName, "o", "", "output file name")
+	fs.StringVar(&outputFileTemplate, "o", "", "output file template. possible placeholders: target_path, tags: example: `gb build -o '{{.target_path}}-{{.tags}}'`")
 	fs.BoolVar(&R, "r", false, "perform a release build")
 	fs.BoolVar(&F, "f", false, "rebuild up-to-date packages")
 	fs.BoolVar(&FF, "F", false, "do not cache built packages")

--- a/cmd/gb/main.go
+++ b/cmd/gb/main.go
@@ -187,6 +187,7 @@ func newContext(cwd string) (*gb.Context, error) {
 		gb.Gcflags(gcflags...),
 		gb.Ldflags(ldflags...),
 		gb.Tags(buildtags...),
+		gb.OutputFileName(outputFileName),
 		func(c *gb.Context) error {
 			if !race {
 				return nil

--- a/cmd/gb/main.go
+++ b/cmd/gb/main.go
@@ -187,7 +187,7 @@ func newContext(cwd string) (*gb.Context, error) {
 		gb.Gcflags(gcflags...),
 		gb.Ldflags(ldflags...),
 		gb.Tags(buildtags...),
-		gb.OutputFileName(outputFileName),
+		gb.OutputFileTemplate(outputFileTemplate),
 		func(c *gb.Context) error {
 			if !race {
 				return nil

--- a/context.go
+++ b/context.go
@@ -58,6 +58,8 @@ type Context struct {
 	linkmode, buildmode string // link and build modes
 
 	buildtags []string // build tags
+
+	outputBinFileName string
 }
 
 // GOOS configures the Context to use goos as the target os.
@@ -86,6 +88,14 @@ func GOARCH(goarch string) func(*Context) error {
 func Tags(tags ...string) func(*Context) error {
 	return func(c *Context) error {
 		c.buildtags = append(c.buildtags, tags...)
+		return nil
+	}
+}
+
+// OutputFileName configured the context to use output file name for produced bin
+func OutputFileName(outputFileName string) func(*Context) error {
+	return func(c *Context) error {
+		c.outputBinFileName = outputFileName
 		return nil
 	}
 }

--- a/context.go
+++ b/context.go
@@ -59,7 +59,7 @@ type Context struct {
 
 	buildtags []string // build tags
 
-	outputBinFileName string
+	outputBinFileTemplate string
 }
 
 // GOOS configures the Context to use goos as the target os.
@@ -92,10 +92,10 @@ func Tags(tags ...string) func(*Context) error {
 	}
 }
 
-// OutputFileName configured the context to use output file name for produced bin
-func OutputFileName(outputFileName string) func(*Context) error {
+// OutputFileTemplate configured the context to use output file name for produced bin
+func OutputFileTemplate(outputFileTemplate string) func(*Context) error {
 	return func(c *Context) error {
-		c.outputBinFileName = outputFileName
+		c.outputBinFileTemplate = outputFileTemplate
 		return nil
 	}
 }

--- a/package.go
+++ b/package.go
@@ -75,6 +75,10 @@ func (p *Package) Complete() bool {
 
 // Binfile returns the destination of the compiled target of this command.
 func (pkg *Package) Binfile() string {
+	if pkg.outputBinFileName != "" {
+		return pkg.outputBinFileName
+	}
+
 	target := filepath.Join(pkg.bindir(), pkg.binname())
 
 	// if this is a cross compile or GOOS/GOARCH are both defined or there are build tags, add ctxString.

--- a/package.go
+++ b/package.go
@@ -1,6 +1,7 @@
 package gb
 
 import (
+	"bytes"
 	"fmt"
 	"go/build"
 	"os"
@@ -8,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 	"time"
+	"text/template"
 
 	"github.com/constabulary/gb/internal/debug"
 	"github.com/pkg/errors"
@@ -75,17 +77,27 @@ func (p *Package) Complete() bool {
 
 // Binfile returns the destination of the compiled target of this command.
 func (pkg *Package) Binfile() string {
-	if pkg.outputBinFileName != "" {
-		return pkg.outputBinFileName
-	}
-
 	target := filepath.Join(pkg.bindir(), pkg.binname())
 
-	// if this is a cross compile or GOOS/GOARCH are both defined or there are build tags, add ctxString.
-	if pkg.isCrossCompile() || (os.Getenv("GOOS") != "" && os.Getenv("GOARCH") != "") {
-		target += "-" + pkg.ctxString()
-	} else if len(pkg.buildtags) > 0 {
-		target += "-" + strings.Join(pkg.buildtags, "-")
+	if pkg.outputBinFileTemplate != "" {
+		params := map[string]string{"target_path": target, "tags": strings.Join(pkg.buildtags, "-")}
+		t, err := template.New("output-file-template").Parse(pkg.outputBinFileTemplate)
+		if err != nil {
+			panic("invalid output file template: " + pkg.outputBinFileTemplate)
+		}
+		buf := new(bytes.Buffer)
+		if err := t.Execute(buf, params); err != nil {
+			panic(fmt.Sprintf("failed to execute output file template %q with params %v: %v",
+				pkg.outputBinFileTemplate, params, err))
+		}
+		target = string(buf.Bytes())
+	} else {
+		// if this is a cross compile or GOOS/GOARCH are both defined or there are build tags, add ctxString.
+		if pkg.isCrossCompile() || (os.Getenv("GOOS") != "" && os.Getenv("GOARCH") != "") {
+			target += "-" + pkg.ctxString()
+		} else if len(pkg.buildtags) > 0 {
+			target += "-" + strings.Join(pkg.buildtags, "-")
+		}
 	}
 
 	if pkg.gotargetos == "windows" {


### PR DESCRIPTION
When we pass tags through gb build for project foo (e.g. gb build -tags 'production monitoring') gb generates bin file foo-production-monitoring while we expects just foo.

The idea is to add -o flag to specify output file template(e.g. db build -tags 'production monitoring' -o '{{.target_path}}-{{.tags}}')